### PR TITLE
refactor: optimise config for usage HtmlBundlerPlugin with handlebars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "express": "^4.18.2",
                 "gh-pages": "^6.1.0",
                 "handlebars": "^4.7.8",
-                "html-bundler-webpack-plugin": "^3.0.0",
+                "html-bundler-webpack-plugin": "^3.5.2",
                 "markdownlint": "^0.33.0",
                 "markdownlint-cli": "^0.39.0",
                 "multer": "^1.4.5-lts.1",
@@ -3451,6 +3451,12 @@
                 "@types/send": "*"
             }
         },
+        "node_modules/@types/html-minifier-terser": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.2.tgz",
+            "integrity": "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==",
+            "dev": true
+        },
         "node_modules/@types/http-errors": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -3969,9 +3975,9 @@
             }
         },
         "node_modules/ansis": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ansis/-/ansis-2.0.1.tgz",
-            "integrity": "sha512-PzC4RaG8fhFHFCL47AcDrQj2gIhIlgx6a46e4WQRvNhJpiPUj9OOyH0VkjH0yKvdl4umrxrVGNWXO6zvbIKgTw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-2.0.3.tgz",
+            "integrity": "sha512-tcSGX0mhuDFHsgRrT56xnZ9v2X+TOeKhJ75YopI5OBgyT7tGaG5m6BmeC+6KHjiucfBvUHehQMecHbULIAkFPA==",
             "dev": true,
             "engines": {
                 "node": ">=12.13"
@@ -9410,12 +9416,13 @@
             }
         },
         "node_modules/html-bundler-webpack-plugin": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-3.0.3.tgz",
-            "integrity": "sha512-sXOjVzTvmNkb/bs82e6D4XOHDPIJDiT7QCF4G2e0CdivvDZLbtf1FTFp+JMzTbr+22VxizdXLCMZtdfbj4sE4Q==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-3.5.2.tgz",
+            "integrity": "sha512-t+6UdvcB0TAW/cjY6nUY1Dwst/Czf44INX8a48QViZ9xr19tWPkTCUCYs4DJBp9zJCbYzrfmFwFq1ChSe2Gz0A==",
             "dev": true,
             "dependencies": {
-                "ansis": "2.0.1",
+                "@types/html-minifier-terser": "^7.0.2",
+                "ansis": "2.0.3",
                 "enhanced-resolve": ">=5.7.0",
                 "eta": "^3.1.1",
                 "html-minifier-terser": "^7.2.0"
@@ -9432,8 +9439,13 @@
                 "favicons": ">=7.1.4",
                 "handlebars": ">=4.7.7",
                 "liquidjs": ">=10.7.0",
+                "markdown-it": ">=13.0.1",
                 "mustache": ">=4.2.0",
                 "nunjucks": ">=3.2.3",
+                "parse5": ">=7.1.2",
+                "prismjs": ">=1.29.0",
+                "pug": ">=3.0.2",
+                "twig": ">=1.17.1",
                 "webpack": ">=5.32.0"
             },
             "peerDependenciesMeta": {
@@ -9449,10 +9461,25 @@
                 "liquidjs": {
                     "optional": true
                 },
+                "markdown-it": {
+                    "optional": true
+                },
                 "mustache": {
                     "optional": true
                 },
                 "nunjucks": {
+                    "optional": true
+                },
+                "parse5": {
+                    "optional": true
+                },
+                "prismjs": {
+                    "optional": true
+                },
+                "pug": {
+                    "optional": true
+                },
+                "twig": {
                     "optional": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "express": "^4.18.2",
         "gh-pages": "^6.1.0",
         "handlebars": "^4.7.8",
-        "html-bundler-webpack-plugin": "^3.0.0",
+        "html-bundler-webpack-plugin": "^3.5.2",
         "markdownlint": "^0.33.0",
         "markdownlint-cli": "^0.39.0",
         "multer": "^1.4.5-lts.1",

--- a/src/client/context.json
+++ b/src/client/context.json
@@ -19,7 +19,12 @@
                 "prev": "Previous slide"
             }
         },
-        "slides": []
+        "slides": [
+            { "url": "#", "text": "one"},
+            { "url": "#", "text": "two"},
+            { "url": "#", "text": "three"},
+            { "url": "#", "text": "four"}
+        ]
     },
     "contact": {},
     "copyright": {

--- a/src/client/handlebars.js
+++ b/src/client/handlebars.js
@@ -2,8 +2,8 @@ import Handlebars from 'handlebars';
 import fs from 'node:fs';
 import context from './context.json' assert { type: 'json' };
 
-export const PARTIALS_PATH = 'src/client/templates/partials/';
-export const PAGES_PATH = 'src/client/templates/pages/';
+export const PARTIALS_PATH = './src/client/templates/partials/';
+export const PAGES_PATH = './src/client/templates/pages/';
 
 export function callbackPartials(callback, partialsPath = PARTIALS_PATH) {
     const partials = fs.readdirSync(partialsPath);
@@ -66,14 +66,14 @@ export function registerPages(pagesPath) {
     return pages;
 }
 
-Handlebars.registerHelper('idx', (index) => index + 1);
+// This helpers shpould be defined in the `preprocessorOptions.helpers` options of the HtmlBundlerPlugin
+//Handlebars.registerHelper('idx', (index) => index + 1);
 
-Handlebars.registerHelper('len', (object) => object.length);
+//Handlebars.registerHelper('len', (object) => object.length);
 
-Handlebars.registerHelper('assign', function (key, val, options) {
-    if (options.data.root === undefined) {
-        options.data.root = {};
-    }
-
-    options.data.root[key] = val;
-});
+// Handlebars.registerHelper('assign', function (key, val, options) {
+//     if (options.data.root === undefined) {
+//         options.data.root = {};
+//     }
+//     options.data.root[key] = val;
+// });

--- a/src/client/scripts/index.js
+++ b/src/client/scripts/index.js
@@ -1,11 +1,11 @@
-// import { Carousel } from './carousel.js';
-// import { Navigation } from './navigation.js';
-// import { Menu } from './menu.js';
+import { Carousel } from './carousel.js';
+import { Navigation } from './navigation.js';
+import { Menu } from './menu.js';
 
 (() => {
     document.addEventListener('DOMContentLoaded', () => {
-        // new Menu();
-        // new Navigation();
-        // new Carousel({ id: 'carousel-banner' });
+        new Menu();
+        new Navigation();
+        new Carousel({ id: 'carousel-banner' });
     });
 })();

--- a/src/client/templates/partials/base.hbs
+++ b/src/client/templates/partials/base.hbs
@@ -14,23 +14,22 @@
         {{> icons }}
         <header class="header">
             <div class="wrapper header-wrapper">
-                {{!-- {{> logo }}
+                {{> logo }}
                 {{> nav-primary class="nav-header" }}
                 {{> menu-button }}
-                {{> menu}} --}}
+                {{> menu}}
             </div>
         </header>
         <main>
-            {{!-- {{> carousel id="carousel-banner" }} --}}
+            {{> carousel id="carousel-banner" }}
             <div class="wrapper">
-                {{!-- {{#>main}}
+                {{#>main}}
                 {{> @partial-block }}
-                {{/main}} --}}
+                {{/main}}
             </div>
         </main>
         <footer>
             <div class="wrapper">
-                {{!--
                 <div class="container">
                     <img
                         class="image image-logo"
@@ -54,7 +53,6 @@
                     {{> separator class="separator-sub" }}
                     {{> author }}
                 </div>
-                --}}
             </div>
         </footer>
         <script src="@scripts/index.js"></script>


### PR DESCRIPTION
# Pull Request

## Description

Hello @MenSeb,

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) and I want to demonstrate how to configure this plugin for usage with `handlebars`.

The HTML Bundler Plugin supports many templating engines out of the box including the `handlebars` engine.
Just define the `preprocessor` plugin option as `handlebars` and define the handlebars options under the `preprocessorOptions`, see my comments in PR.

I have uncommented JS and templates to check whether my changes works.

You don't need to use the `WatchPartialsPlugin`, because the Bundler Plugin can watch changes in all partials from paths defined in the `preprocessorOptions.views` and `preprocessorOptions. partials` options.

Your custom handlebars helpers you can define in the `preprocessorOptions.helpers` options.

## Behavior

Please describe the current behavior:

## Changes

Please describe the new behavior:

- uncommented template partials to views generated HTML content
- uncommented JS code to init components
- optimized webpack config

## Breaking Change

Does your changes introduce a breaking change?

- [ x] no
- [ ] yes

## Information (issue, links, logs, etc.)

Please list any other useful information:
